### PR TITLE
fix: replace deprecated GitHub Copilot extension with GitHub Copilot Chat

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,6 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "GitHub.copilot",
         "GitHub.copilot-chat"
       ],
       "settings": {

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
   "recommendations": [
-    "GitHub.copilot",
     "GitHub.copilot-chat"
   ]
 }


### PR DESCRIPTION
## Summary

The [`GitHub.copilot`](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) extension has been deprecated in favor of [`GitHub.copilot-chat`](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat), which combines inline code suggestions and chat features into a single extension.

This PR removes the deprecated `GitHub.copilot` and keeps `GitHub.copilot-chat` as the sole recommended extension in:
- `.vscode/extensions.json`
- `.devcontainer/devcontainer.json`