### PR TITLE
Fix: notify CMD when agent run is cancelled or times out

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -7,9 +7,39 @@ on:
 
 jobs:
   test:
-    name: ${{ github.event.action}}
+    name: ${{ github.event.action }}
     runs-on: self-hosted
+    timeout-minutes: 30
     steps:
-      - uses: Wopee-io/run-agent@v1
+      - uses: Wopee-io-DEV/run-agent@v1
         env:
           WOPEE_API_KEY: ${{ secrets.WOPEE_API_KEY }}
+
+      - name: Notify CMD on cancellation or timeout
+        if: cancelled()
+        shell: bash
+        run: |
+          SUITE_UUID="${{ github.event.client_payload.suite.uuid }}"
+          PROJECT_UUID="${{ github.event.client_payload.projectUuid }}"
+          ACTION="${{ github.event.action }}"
+          API_URL="${{ github.event.client_payload.apiUrl || 'https://api.wopee.io' }}"
+
+          if [ -z "$SUITE_UUID" ] || [ -z "$PROJECT_UUID" ]; then
+            echo "⚠️ Missing suite or project UUID — cannot notify CMD"
+            exit 0
+          fi
+
+          if [ "$ACTION" = "crawl" ]; then
+            QUERY='mutation PostProcessAnalysisSuite($input: PostProcessAnalysisSuiteInput!) { postProcessAnalysisSuite(input: $input) }'
+          else
+            QUERY='mutation PostProcessAgentSuite($input: PostProcessAgentSuiteInput!) { postProcessAgentSuite(input: $input) }'
+          fi
+
+          echo "Notifying CMD that run was cancelled/timed out..."
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --header "content-type: application/json" \
+            --header "api_key: ${{ secrets.WOPEE_API_KEY }}" \
+            --url "$API_URL" \
+            --data "{\"query\":\"$QUERY\",\"variables\":{\"input\":{\"error\":true,\"projectUuid\":\"$PROJECT_UUID\",\"suiteUuid\":\"$SUITE_UUID\"}}}" \
+            || echo "⚠️ CMD notification failed"


### PR DESCRIPTION
## Problem

When a GitHub Actions job is cancelled (manually or by `timeout-minutes`), CMD keeps showing the run as **"In progress" forever**. The agent never gets a chance to call the CMD API to report completion.

### Why this happens

The `run-agent@v1` composite action has a cleanup step (`"Confirm end of run"`) with `if: always()`. However, **GitHub Actions skips ALL composite action steps when the parent job is cancelled** — `if: always()` only works on job-level steps, not on steps inside a composite action.

This was validated across 8 cancelled runs in the Generali agent test (2026-03-28). Zero out of 8 cancelled runs had the `postProcess` mutation reach CMD.

## Fix

1. **Add a job-level step** with `if: cancelled()` that calls the CMD API directly to mark the run as errored
2. **Add `timeout-minutes: 30`** to prevent infinite hangs (agents that get stuck will be killed after 30 min instead of running for 6+ hours)
3. **Fix org name** `Wopee-io` → `Wopee-io-DEV` (correct GitHub org for `run-agent`)

## What changes

| Before | After |
|--------|-------|
| No timeout — stuck agents run forever | 30-min hard limit |
| Cancelled runs → CMD stuck "In progress" | Cancelled runs → CMD notified (marked as error) |
| `Wopee-io/run-agent@v1` (wrong org) | `Wopee-io-DEV/run-agent@v1` (correct org) |

## How it works

The new step only runs when the job is cancelled (`if: cancelled()`). It reads the suite UUID and project UUID from the `client_payload` (same data CMD sends when dispatching) and calls the same `postProcessAnalysisSuite` / `postProcessAgentSuite` mutation that `run-agent@v1` would call on normal completion — but with `error: true`.

## Rollout

After merging, this template change needs to be propagated to existing `pw-<uuid>` project repos. Each project repo has its own copy of `agent.yml`.